### PR TITLE
Fix page jumping on iOS by replacing scrollIntoView with scrollTo

### DIFF
--- a/src/cube/presentation/gui/backends/webgl/static/js/HistoryPanel.js
+++ b/src/cube/presentation/gui/backends/webgl/static/js/HistoryPanel.js
@@ -130,11 +130,15 @@ export class HistoryPanel {
 
         this._updateButtons();
 
-        // Scroll to NOW marker
+        // Scroll to NOW marker (use scrollTop instead of scrollIntoView
+        // to avoid scrolling the entire page on mobile Safari)
         requestAnimationFrame(() => {
             const marker = this._list.querySelector('.hp-marker');
             if (marker) {
-                marker.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                const list = this._list;
+                const targetTop = marker.offsetTop - list.offsetTop
+                    - list.clientHeight / 2 + marker.offsetHeight / 2;
+                list.scrollTo({ top: targetTop, behavior: 'smooth' });
             }
         });
     }


### PR DESCRIPTION
scrollIntoView() scrolls every ancestor container, not just the history panel list. On iOS Safari this caused the entire page to jump down when the history panel updated (e.g. after scramble+solve). Replace with manual scrollTop calculation scoped to the history list element only.

https://claude.ai/code/session_019MD8G5t4H44bWQibv6xWBr