### PR TITLE
Add marker meet animation when annotation context finishes

### DIFF
--- a/src/cube/presentation/gui/backends/webgl/ClientSession.py
+++ b/src/cube/presentation/gui/backends/webgl/ClientSession.py
@@ -1584,11 +1584,10 @@ class ClientSession:
             return
 
         try:
-            alg = parse_alg(text)
-            # Check that it actually contains moves (not just whitespace that parsed to empty)
-            moves = list(alg.flatten())
-            valid = len(moves) > 0
-            self._send(json.dumps({"type": "parse_alg_result", "valid": valid, "error": ""}))
+            parse_alg(text)
+            # If parse_alg succeeds, the algorithm is valid (even if it reduces
+            # to identity, e.g. U4, U8, U20 — these are valid no-op algorithms)
+            self._send(json.dumps({"type": "parse_alg_result", "valid": True, "error": ""}))
         except (InternalSWError, Exception) as e:
             self._send(json.dumps({"type": "parse_alg_result", "valid": False, "error": str(e)}))
 


### PR DESCRIPTION
When a solver annotation exits (source marker reaches target), play a
flash/pulse "meeting" animation before removing markers. New MarkerMeetAlg
signals the WebGL client to animate, blocking the solver until done.

- MarkerMeetAlg: AnnotationAlg subclass carrying duration_ms
- Algs.AM singleton played in OpAnnotation finally block (try/except guarded)
- WebglAnimationManager handles MarkerMeetAlg in both blocking and queue modes
- ClientSession.send_marker_meet() sends event to client
- JS MarkerAnimator.playMeetAnimation(): flash (scale 1.3x) then fade
- JS only animates stickers where BOTH fixed and moveable markers are present
- Fix pre-existing pyright error in Operator.with_buffer return type

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>