### PR TITLE
Fix 2x2 beginner solver: replace swap algorithm with Y-rotation approach

### DIFF
--- a/src/cube/domain/solver/_2x2_beginner/Solver2x2Beginner.py
+++ b/src/cube/domain/solver/_2x2_beginner/Solver2x2Beginner.py
@@ -101,6 +101,8 @@ class Solver2x2Beginner(Solver2x2Base):
                 assert l1_result
                 l1_face, l1_color = l1_result
                 self._solve_l3(l1_face, l1_color)
+                if self._l3_permute.swap_detected:
+                    sr.was_corner_swap = True
 
         return sr
 

--- a/src/cube/domain/solver/_2x2_beginner/_L3Permute.py
+++ b/src/cube/domain/solver/_2x2_beginner/_L3Permute.py
@@ -33,7 +33,7 @@ class L3Permute(StepSolver):
     Works purely with corner sticker colors — no face colors.
     """
 
-    __slots__: list[str] = []
+    __slots__: list[str] = ["_swap_detected"]
 
     # U R U' L' U R' U' L — 3-corner cycle, fixes FRU, cycles FLU/BRU/BLU
     _CYCLE: Alg = Algs.alg(
@@ -44,6 +44,12 @@ class L3Permute(StepSolver):
 
     def __init__(self, slv: SolverElementsProvider) -> None:
         super().__init__(slv, "L3Permute")
+        self._swap_detected: bool = False
+
+    @property
+    def swap_detected(self) -> bool:
+        """Whether a FLU↔BLU corner swap was detected during the last solve."""
+        return self._swap_detected
 
     @property
     def is_solved(self) -> bool:
@@ -69,6 +75,7 @@ class L3Permute(StepSolver):
 
     def solve(self, white_color: Color | None = None) -> None:
         """Permute last-layer corners into correct positions."""
+        self._swap_detected = False
         wc: Color = white_color or self.cmn.white
         if self.is_solved_with(wc):
             self._align_u_layer(wc)
@@ -134,6 +141,7 @@ class L3Permute(StepSolver):
                 return  # done!
 
             # FLU↔BLU are swapped — break the swap with cycle, U2, cycle
+            self._swap_detected = True
             with self.ann.annotate(
                     (up.corner_bottom_left, AnnWhat.Moved),
                     (up.corner_top_left, AnnWhat.Moved),


### PR DESCRIPTION
The 2x2 beginner solver's corner permutation step used a sophisticated
T-perm variant (R' F R' B2 R F' R' B2 R2 U') for parity cases. This
is inappropriate for a "beginner" solver that should only use the
3-cycle algorithm the learner already knows.

New approach uses only the 3-cycle (U' L' U R U' L U R') plus Y and D
rotations:
- Find any corner in position; if none (derangement), one 3-cycle
  creates a fixed point for even permutations
- Y-rotate the in-position corner to FLU (preserves top-bottom matching)
- Apply 3-cycle 1-2 times to solve remaining corners
- For odd permutations (2x2 parity), undo and apply D to flip parity

https://claude.ai/code/session_016qdskceb4KekiNR9k97hHC